### PR TITLE
Support ActiveSupport 5+ version

### DIFF
--- a/lib/transitions/graph.rb
+++ b/lib/transitions/graph.rb
@@ -5,12 +5,25 @@ module Transitions
     def initialize(class_name, options = {})
       options = {path: '.'}.merge(options)
 
-      @file_path = File.join(options[:path], "#{class_name.parameterize('_')}_transitions.png")
+      if active_support_less_than_version_5?
+        file_name = "#{class_name.parameterize('_')}_transitions.png"
+      else
+        file_name = "#{class_name.parameterize(separator: '_')}_transitions.png"
+      end
+
+      @file_path = File.join(options[:path], file_name)
+
       super(:G)
     end
 
     def output
       super png: @file_path
+    end
+
+    private
+
+    def active_support_less_than_version_5?
+      ActiveSupport.version < Gem::Version.new('5')
     end
   end
 end


### PR DESCRIPTION
It supports`String#parameterize` call with position parameter for separator (ActiveSupport < 5) and named parameters (ActiveSupport >= 5)